### PR TITLE
Add airplay support

### DIFF
--- a/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/SwiftSampleViewController.swift
+++ b/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/SwiftSampleViewController.swift
@@ -25,6 +25,7 @@ class SwiftSampleViewController: AVPlayerViewController {
     super.viewDidAppear(animated)
     initDeliveryClient()
     playContent()
+    registerAirplayNotification()
   }
   
   // MARK: - Player init
@@ -75,4 +76,38 @@ class SwiftSampleViewController: AVPlayerViewController {
     #endif
   }
   
+  // MARK: - Airplay support
+  
+  /// To detect actual airplay switc we can use the device audio output
+  // we need to register to AVAudioSession.routeChangeNotification
+  private func registerAirplayNotification() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(audioOutputDidChange),
+      name: AVAudioSession.routeChangeNotification,
+      object: AVAudioSession.sharedInstance())
+  }
+  
+  @objc func audioOutputDidChange() {
+    // Get the current audio route
+    let currentRoute = AVAudioSession.sharedInstance().currentRoute
+    // Check if the audio  output is an airplay type
+    guard let airplayOutput = currentRoute.outputs.filter({$0.portType == .airPlay}).first else {
+      return
+    }
+    // Save the current playbacktime
+    let time = self.player?.currentTime()
+    
+    // Create a player item with the original url
+    let newItem  = AVPlayerItem(url: manifestUrl)
+    // Replace the player item to bypass local proxy
+    self.player?.replaceCurrentItem(with: newItem)
+    
+    // Seek to last saved time, especially helpful for VOD streams
+    if time != nil {
+      self.player?.seek(to: time!)
+    }
+    print("Airplay device name: \(airplayOutput.portName)")
+  }
+    
 }

--- a/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/SwiftSampleViewController.swift
+++ b/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/SwiftSampleViewController.swift
@@ -19,6 +19,9 @@ class SwiftSampleViewController: AVPlayerViewController {
   override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     deliveryClient?.stop()
+    NotificationCenter.default.removeObserver(self,
+                                              name: AVAudioSession.routeChangeNotification,
+                                              object: AVAudioSession.sharedInstance())
   }
   
   override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
When orchestrator is activated the player is given a local manifest url so we can intercept the player requests.

In the case of Airplay, this solution won't work as the casting device does not have access to the localhost of another device.

One solution we used is to detect when the stream is being cast through an airplay device and replace the local stream by the original one.

For that, we used `AVAudioSession.routeChangeNotification` to detect output changes and overlay the playback control to the casting player.