### PR TITLE
Rename iOS Orchestrator client usage

### DIFF
--- a/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/AVPlayerOrchestrator-Bridging-Header.h
+++ b/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/AVPlayerOrchestrator-Bridging-Header.h
@@ -2,4 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <CTLOrchestratorSDK/CTLOrchestratorSDK.h>
+#import <LumenOrchestratorSDK/LumenOrchestratorSDK.h>

--- a/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/AppDelegate.swift
+++ b/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    CTLDeliveryClient.initializeApp();
+    LMDeliveryClient.initializeApp();
     return true
   }
 }

--- a/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/QosModuleWrapper.swift
+++ b/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/QosModuleWrapper.swift
@@ -10,14 +10,14 @@ import AVKit
 
 class QoSModuleWrapper: NSObject {
   
-  var qosModule: CTLQosModule
+  var qosModule: LMQosModule
   fileprivate var player: AVPlayer?
-  fileprivate var playbackState: CTLPlaybackState
+  fileprivate var playbackState: LMPlaybackState
   
   fileprivate var observer: Any?
   
   override init() {
-    self.qosModule = CTLQosModule(type: .custom)
+    self.qosModule = LMQosModule(type: .custom)
     self.playbackState = .idle
     super.init()
   }
@@ -69,7 +69,7 @@ class QoSModuleWrapper: NSObject {
     player?.removeObserver(self, forKeyPath: "rate")
   }
   
-  fileprivate func updateState(_ state: CTLPlaybackState) {
+  fileprivate func updateState(_ state: LMPlaybackState) {
     if playbackState != state {
       qosModule.playerStateDidChange(state)
       playbackState = state

--- a/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/SwiftSampleViewController.swift
+++ b/orchestrator/Apple/AVPlayer/AVPlayerOrchestrator/SwiftSampleViewController.swift
@@ -11,7 +11,7 @@ import AVKit
 class SwiftSampleViewController: AVPlayerViewController {
   
   // MARK: - Properties
-  private var deliveryClient: CTLDeliveryClient?
+  private var deliveryClient: LMDeliveryClient?
   private var qosModuleWrapper: QoSModuleWrapper!
   private let manifestUrl = URL(string: "http://wowza-test.streamroot.io/liveOrigin/BBB-bl-1500/playlist.m3u8")!
   
@@ -42,7 +42,7 @@ class SwiftSampleViewController: AVPlayerViewController {
     // Instanciate QOS module
     qosModuleWrapper = QoSModuleWrapper()
     // Build the delivery client with parameters
-    deliveryClient = CTLDeliveryClientBuilder.clientBuilder()
+    deliveryClient = LMDeliveryClientBuilder.clientBuilder()
       .qosModule(qosModuleWrapper.qosModule)
       // the streamroot key will default to the one in the Info.plist if not overridden here
       //.deliveryClientKey("demoswebsiteandpartners")

--- a/orchestrator/Apple/AVPlayer/Cartfile
+++ b/orchestrator/Apple/AVPlayer/Cartfile
@@ -1,1 +1,1 @@
-binary "https://sdk.streamroot.io/ios/CTLOrchestratorSDK.json"
+binary "https://sdk.streamroot.io/ios/LumenOrchestratorSDK.json"

--- a/orchestrator/Apple/AVPlayer/Podfile
+++ b/orchestrator/Apple/AVPlayer/Podfile
@@ -3,7 +3,7 @@ inhibit_all_warnings!
 use_frameworks!
 
 def streamrootPod
-  pod 'CTLOrchestratorSDK'
+  pod 'LumenOrchestratorSDK'
 end
 
 target 'AVPlayerOrchestrator' do

--- a/orchestrator/Apple/AVPlayer/README.md
+++ b/orchestrator/Apple/AVPlayer/README.md
@@ -10,7 +10,7 @@ Get the SDK via [cocoapods](https://cocoapods.org/) -> `pod install` in the curr
 ```
 target 'MyApp' do
   use_frameworks!
-  pod 'CTLOrchestratorSDK'
+  pod 'LumenOrchestratorSDK'
 end
 ```
 
@@ -18,7 +18,7 @@ end
 
 Add the orchestrator dependency to the Cartfile, more info on [Carthage installation](https://github.com/Carthage/Carthage#quick-start) method.
 ```
-binary "https://sdk.streamroot.io/ios/CTLOrchestratorSDK.json"
+binary "https://sdk.streamroot.io/ios/LumenOrchestratorSDK.json"
 ```
 
 ### 2 - Set the ClientDeliveryKey
@@ -49,7 +49,7 @@ Add the following lines with the right parameters values.
 The SDK has been implemented in Objective-C, so to import it in a swift project a bridge-header is needed. [More info](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis).
 
 ```
-#import <CTLOrchestratorSDK/CTLOrchestratorSDK.h>
+#import <LumenOrchestratorSDK/LumenOrchestratorSDK.h>
 ```
 
 ## Code integration
@@ -57,18 +57,18 @@ The SDK has been implemented in Objective-C, so to import it in a swift project 
 ### 1 - Initialize the Delivery SDK from the App delegate [application(_:didFinishLaunchingWithOptions:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application)
 
 ```
- CTLDeliveryClient.initializeApp()
+ LMDeliveryClient.initializeApp()
 ```
 
 ### 2 - Build and start the DeliveryClient
 Declare the deliverClient as an instance variable:
 ```
-var deliveryClient: CTLDeliveryClient?
+var deliveryClient: LMDeliveryClient?
 ```
 
 Build the delivery client with the mandatory fields which are the `qosModule`, `orchestratorProperty`, and the `manifestUrl`
 ```swift
-deliveryClient = CTLDeliveryClientBuilder.clientBuilder()
+deliveryClient = LMDeliveryClientBuilder.clientBuilder()
     .qosModule(<#qosModule#>)
      .contentId(<#string#>)
      .orchestratorProperty(<#string#>)   
@@ -83,8 +83,8 @@ In this example, the QOSWrapper is a Helper class of the sample app project, wit
 
 The qosModule can be instantiated as following: 
 ```
-var qosModule: CTLQosModule // Stored property
-self.qosModule = CTLQosModule(type: .custom)
+var qosModule: LMQosModule // Stored property
+self.qosModule = LMQosModule(type: .custom)
 ```
 
 ### 3 - Play the stream


### PR DESCRIPTION
Migrate to the new Lumen Orchestrator SDK